### PR TITLE
Add check for no width or height in previewImageLoaded

### DIFF
--- a/src/js/view/createImageWrapperView.js
+++ b/src/js/view/createImageWrapperView.js
@@ -270,6 +270,10 @@ export const createImageWrapperView = _ => {
 
             // get width and height from action, and swap if orientation is incorrect
             let { width, height } = imageData;
+
+            // if no width or height, just return early.
+            if (!width || !height) return;
+
             if (orientation >= 5 && orientation <= 8) {
                 [width, height] = [height, width];
             }


### PR DESCRIPTION
Fixes #44 by returning early if images have no width or height in previewImageLoaded. 

There's probably a better solution to this that can somehow figure out the width and height from the viewbox attribute, but this at least allows the image to continue uploading. 


