### PR TITLE
Fixing conditional bug for browser detection.

### DIFF
--- a/src/js/view/createImageWrapperView.js
+++ b/src/js/view/createImageWrapperView.js
@@ -209,7 +209,7 @@ export const createImageWrapperView = (_) => {
     const userAgent = window.navigator.userAgent;
     const isFirefox = userAgent.match(/Firefox\/([0-9]+)\./);
     const firefoxVersion = isFirefox ? parseInt(isFirefox[1]) : null;
-    if (firefoxVersion <= 58) return false;
+    if (firefoxVersion !== null && firefoxVersion <= 58) return false;
 
     return "createImageBitmap" in window && isBitmap(file);
   };


### PR DESCRIPTION
The problem lies in the if condition that checks `firefoxVersion <= 58`. If isFirefox is `null`, meaning the user agent does not match Firefox, then `firefoxVersion` will be set to `null`, and the condition `null <= 58` will always be false, causing the function to return false even for non-Firefox browsers.

The bug has been resolved by adding a check for both `firefoxVersion !== null && firefoxVersion <= 58`. 